### PR TITLE
fix go sdk gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ install_provider:: build_provider
 # Go SDK
 
 gen_go_sdk::
-	rm -rf go
+	rm -rf sdk/go
 	cd provider/cmd/${CODEGEN} && go run . go ../../../sdk/go ${SCHEMA_PATH}
 
 


### PR DESCRIPTION
noticed that my go SDK wasn't getting regen'd properly. This fixes the rm path.